### PR TITLE
Add preceding slash to subdirectory path 

### DIFF
--- a/extension/popup/memory_cache.js
+++ b/extension/popup/memory_cache.js
@@ -1,4 +1,4 @@
-const DOWNLOAD_SUBDIRECTORY = "MemoryCache";
+const DOWNLOAD_SUBDIRECTORY = "/MemoryCache";
 
 /*
 Generate a file name based on date and time


### PR DESCRIPTION
Previously, the extension would create a DownloadsMemoryCache folder instead of Downloads/MemoryCache. This fixed it, but I'm not sure if there's a better way. 