### PR TITLE
Updating position and styling of 'Docs'

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -19,13 +19,13 @@
         </label>
 
         <div class="trigger">
+          <a class="page-link" target="_blank" href="https://github.com/Mozilla-Ocho/Memory-Cache/wiki">Docs</a>
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}
             {%- if my_page.title -%}
             <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
             {%- endif -%}
           {%- endfor -%}
-           <a target="_blank" href="https://github.com/Mozilla-Ocho/Memory-Cache/wiki">Docs</a>
         </div>
       </nav>
     {%- endif -%}


### PR DESCRIPTION
This should fix the incorrect styling and position of 'Docs'
<img width="909" alt="Screenshot 2024-01-19 at 11 23 03 AM" src="https://github.com/Mozilla-Ocho/Memory-Cache/assets/100849201/f82c4f24-5314-40f5-bbc0-a7dde713f527">

Going to look into setting up a local build of the site on a non-macbook that won't conflict with gem in so many ways. This will make these edits much less tedious in the future