### PR TITLE
Fix the generated filename for pdfs

### DIFF
--- a/extension/popup/memory_cache.js
+++ b/extension/popup/memory_cache.js
@@ -16,7 +16,16 @@ async function generateFileName(ext) {
       }
     })
     .then ((fileName)=> {
-      return fileName.replaceAll(":","");
+      return fileName.replaceAll(":","")
+                     .replaceAll("!","")
+                      .replaceAll("?","")
+                      .replaceAll("/","")
+                      .replaceAll("\\","")
+                      .replaceAll("*","")
+                      .replaceAll("|","")
+                      .replaceAll(" ","")
+                      .replaceAll("<","")
+                      .replaceAll(">","");
     })
     .catch((error) => {
       reject(`Error querying tabs: ${error}`);
@@ -34,7 +43,7 @@ async function savePDF() {
     // Fallback to non-silent mode.
     await browser.tabs.saveAsPDF({
       // Omit the DOWNLOAD_SUBDIRECTORY prefix because saveAsPDF will not respect it.
-      toFileName: `PAGE-${generateFileName("pdf")}`,
+      toFileName: `PAGE-${await generateFileName("pdf")}`,
     });
   }
 }


### PR DESCRIPTION
We forgot to `await` the promise returned by `generateFileName`, so the generated file names were `PAGE-[Object object]` (which came from stringifying the promise object).